### PR TITLE
make the code correspond to scaladoc

### DIFF
--- a/OpenCV2_Cookbook/src/main/scala/opencv2_cookbook/chapter11/VideoProcessor.scala
+++ b/OpenCV2_Cookbook/src/main/scala/opencv2_cookbook/chapter11/VideoProcessor.scala
@@ -21,7 +21,7 @@ import org.bytedeco.javacv.CanvasFrame
   * @param displayOutput name for the window displaying output image,
   *                      If empty, output image will not be displayed.
   */
-class VideoProcessor(var frameProcessor: ((Mat, Mat) => Unit) = { (src, dest) => dest.copyTo(dest) },
+class VideoProcessor(var frameProcessor: ((Mat, Mat) => Unit) = { (src, dest) => src.copyTo(dest) },
                      var displayInput: String = "Input",
                      var displayOutput: String = "Output") {
 


### PR DESCRIPTION
Scaladoc says that frameProcessor by default copies the input, but it does a different thing.